### PR TITLE
[#52] Add after_initialize and after_find callbacks

### DIFF
--- a/lib/ducalis/cops/callbacks_activerecord.rb
+++ b/lib/ducalis/cops/callbacks_activerecord.rb
@@ -18,8 +18,11 @@ module Ducalis
       after_commit
       after_create
       after_destroy
+      after_find
+      after_initialize
       after_rollback
       after_save
+      after_touch
       after_update
       after_validation
       around_create


### PR DESCRIPTION
Which are pure evil!

```ruby
User.where(id: [13257, 13258, 13660]).pluck(:tax_id) #=> [nil, nil, 28]
User.where(id: [13257, 13258, 13660]).map(&:tax_id) #=> [28, 28, 28]
```

because of

```ruby
after_initialize :add_tax
```

Aaaaaaaaaaa!