### PR TITLE
[#59] Add update_attributes as alias for update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.8
-  - 2.3.4
-  - 2.4.2
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
 before_install:
   - gem update --system
   - gem --version
+  - gem install bundler

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -630,6 +630,11 @@ User.where(id: 7).delete
 User.where(id: 7).save(validate: false)
 ```
 
+![](https://placehold.it/10/f03c15/000000?text=+) raises `update_column` method calling
+```ruby
+User.where(id: 7).update_column(admin: false)
+```
+
 ![](https://placehold.it/10/f03c15/000000?text=+) raises `toggle!` method calling
 ```ruby
 User.where(id: 7).toggle!
@@ -743,6 +748,16 @@ Group.find(8)
 ![](https://placehold.it/10/f03c15/000000?text=+) raises if AR search was called even for chain of calls
 ```ruby
 Group.includes(:profiles).find(8)
+```
+
+![](https://placehold.it/10/f03c15/000000?text=+) raises if AR search was called with find_by id
+```ruby
+Group.includes(:profiles).find_by(id: 8)
+```
+
+![](https://placehold.it/10/f03c15/000000?text=+) raises if AR search was called on unnamespaced constant
+```ruby
+::Group.find(8)
 ```
 
 ![](https://placehold.it/10/f03c15/000000?text=+) ignores where statements and still raises error

--- a/lib/ducalis/cops/preferable_methods.rb
+++ b/lib/ducalis/cops/preferable_methods.rb
@@ -19,15 +19,44 @@ module Ducalis
     end
 
     DESCRIPTION = {
-      # Method => [Alternative, Reason, Callable condition]
-      toggle!: ['toggle.save', 'it is not invoking validations', ALWAYS_TRUE],
-      save: [:save, 'it is not invoking validations', VALIDATE_CHECK],
-      delete: [:destroy, 'it is not invoking callbacks', DELETE_CHECK],
-      delete_all: [:destroy_all, 'it is not invoking callbacks', ALWAYS_TRUE],
-      update_attribute: [:update, 'it is not invoking validation', ALWAYS_TRUE],
-      update_column: [:update, 'it is not invoking callbacks', ALWAYS_TRUE],
+      # Method => [
+      #   Alternative,
+      #   Reason,
+      #   Callable condition
+      # ]
+      toggle!: [
+        '`toggle.save`',
+        'it is not invoking validations',
+        ALWAYS_TRUE
+      ],
+      save: [
+        '`save`',
+        'it is not invoking validations',
+        VALIDATE_CHECK
+      ],
+      delete: [
+        '`destroy`',
+        'it is not invoking callbacks',
+        DELETE_CHECK
+      ],
+      delete_all: [
+        '`destroy_all`',
+        'it is not invoking callbacks',
+        ALWAYS_TRUE
+      ],
+      update_attribute: [
+        '`update` (`update_attributes` for Rails versions < 4)',
+        'it is not invoking validations',
+        ALWAYS_TRUE
+      ],
+      update_column: [
+        '`update` (`update_attributes` for Rails versions < 4)',
+        'it is not invoking callbacks',
+        ALWAYS_TRUE
+      ],
       update_columns: [
-        :update, 'it is not invoking validations, callbacks and updated_at',
+        '`update` (`update_attributes` for Rails versions < 4)',
+        'it is not invoking validations, callbacks and updated_at',
         ALWAYS_TRUE
       ]
     }.freeze

--- a/spec/ducalis/cops/preferable_methods_spec.rb
+++ b/spec/ducalis/cops/preferable_methods_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Ducalis::PreferableMethods do
     expect(cop).to raise_violation(/save/)
   end
 
+  it 'raises `update_column` method calling' do
+    inspect_source(cop, 'User.where(id: 7).update_column(admin: false)')
+    expect(cop).to raise_violation(/update/)
+    expect(cop).to raise_violation(/update_attributes/)
+  end
+
   it 'raises `toggle!` method calling' do
     inspect_source(cop, 'User.where(id: 7).toggle!')
     expect(cop).to raise_violation(/toggle.save/)


### PR DESCRIPTION
Add comment which describes alternative method for Rails version less
than 4. In Rails 4 update_attributes aliased to update, so seems like it
is a reasonable substitution for it.