### PR TITLE
[#18] Remove thor dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       policial (= 0.0.4)
       regexp-examples (~> 1.3, >= 1.3.2)
       rubocop (~> 0.46.0, >= 0.45.0)
-      thor (~> 0.20.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +35,7 @@ GEM
     method_source (0.9.0)
     multi_json (1.12.2)
     multipart-post (2.0.0)
-    octokit (4.7.0)
+    octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parser (2.4.0.2)
       ast (~> 2.3)
@@ -77,7 +76,6 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    thor (0.20.0)
     unicode-display_width (1.3.0)
 
 PLATFORMS

--- a/bin/ducalis
+++ b/bin/ducalis
@@ -15,13 +15,12 @@ Env `GITHUB_TOKEN` should be available to receive PRs files."
   puts '    --all   [default] check all files in RuboCop style.'
   puts ''
 
-  Ducalis::CLI.start(ARGV)
-  RuboCop::CLI.new.run
+  Ducalis::CLI.new(ARGV).start
   exit 0
 end
 
 if Ducalis::PassedArgs.ci_mode?
-  Ducalis::CLI.start(ARGV - %w(--ci))
+  Ducalis::CLI.new(ARGV - %w(--ci)).start
 else
   Ducalis::PassedArgs.process_args!
 

--- a/ducalis.gemspec
+++ b/ducalis.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'policial', '0.0.4'
   spec.add_dependency 'regexp-examples', '~> 1.3', '>= 1.3.2'
   spec.add_dependency 'rubocop', '>= 0.45.0', '~> 0.46.0'
-  spec.add_dependency 'thor', '~> 0.20.0'
 end

--- a/lib/ducalis/cli.rb
+++ b/lib/ducalis/cli.rb
@@ -1,35 +1,96 @@
 # frozen_string_literal: true
 
-require 'thor'
+require 'optparse'
 
 module Ducalis
-  class CLI < Thor
+  class CLI
     ADAPTERS = {
       circle: Adapters::CircleCi,
       custom: Adapters::Custom
     }.freeze
     DEFAULT_ADAPTER = ADAPTERS.keys.last
-    default_task :start
 
-    desc '--ci', ''
-    option :adapter, required: true, default: DEFAULT_ADAPTER,
-                     desc: 'Describes how Ducalis will receive PR information'
-    option :id,   type: :numeric, desc: 'PR id, ex: 2347'
-    option :repo, type: :string,  desc: 'PR repository, ex: author/repo'
-    option :sha,  type: :string,  desc: 'Starting commit, can be skipped'
-    option :dry,  type: :boolean, default: false,
-                  desc: 'Allows user run dry mode, default: false'
-    def start
-      adapter = ADAPTERS.fetch(options[:adapter].to_sym) do
-        raise "Unsupported adapter #{options[:adapter]}"
-      end
-      Runner.new(adapter.new(options)).call
+    def initialize(arguments)
+      @arguments = arguments
+      @options   = {}
+      @parser    = OptionParser.new
+      configure_parser!
     end
 
-    desc '--ci help', 'Describe available commands'
-    def help(command = nil, subcommand = false)
-      command ||= :start
-      super
+    def start
+      @parser.parse(@arguments)
+      Runner.new(adapter.new(@options)).call
+    end
+
+    private
+
+    def adapter
+      ADAPTERS.fetch(@options.fetch(:adapter, DEFAULT_ADAPTER)) do
+        raise "Unsupported adapter #{@options[:adapter]}"
+      end
+    end
+
+    def configure_parser!
+      @parser.banner = 'Usage: ducalis --ci --adapter=ADAPTER'
+      adapter_option_parsing
+      id_option_parsing
+      repo_option_parsing
+      sha_option_parsing
+      dry_option_parsing
+      help_command
+    end
+
+    def help_command
+      @parser.on_tail('--help', 'Show this message') do
+        puts @parser
+        RuboCop::CLI.new.run(@arguments)
+      end
+    end
+
+    def adapter_option_parsing
+      @parser.on(
+        '--adapter=ADAPTER',
+        'Describes how Ducalis will receive PR information. Default: custom'
+      ) do |adapter|
+        @options[:adapter] = adapter.to_sym
+      end
+    end
+
+    def id_option_parsing
+      @parser.on(
+        '--id=N',
+        'PR id, ex: 2347'
+      ) do |id|
+        @options[:id] = id
+      end
+    end
+
+    def repo_option_parsing
+      @parser.on(
+        '--repo=REPO',
+        'PR repository, ex: author/repo'
+      ) do |repo|
+        @options[:repo] = repo
+      end
+    end
+
+    def sha_option_parsing
+      @parser.on(
+        '--sha=SHA',
+        'Starting commit, can be omitted'
+      ) do |sha|
+        @options[:sha] = sha
+      end
+    end
+
+    def dry_option_parsing
+      @options[:dry] = false # default
+      @parser.on(
+        '--dry',
+        'Allows user to run dry mode, default: false'
+      ) do |_dry|
+        @options[:dry] = true
+      end
     end
   end
 end

--- a/lib/ducalis/passed_args.rb
+++ b/lib/ducalis/passed_args.rb
@@ -4,10 +4,10 @@ module Ducalis
   module PassedArgs
     module_function
 
-    RUBOCOP_FLAGS = %w(-D).freeze
+    HELP_FLAGS = ['-h', '-?', '--help'].freeze
 
     def help_command?
-      ARGV.any? { |arg| (Thor::HELP_MAPPINGS - RUBOCOP_FLAGS).include?(arg) }
+      ARGV.any? { |arg| HELP_FLAGS.include?(arg) }
     end
 
     def ci_mode?


### PR DESCRIPTION
Trying to remove thor as CLI provider and use default RubyParser. Some
breaking changes like removing --no-dry options (pretty sure nobody uses
it, but who knows). Some styling differents but should be more or less
ok and compatible.