### PR TITLE
[#63] Fix false-positive triggering on gems with require

### DIFF
--- a/spec/ducalis/cops/uncommented_gem_spec.rb
+++ b/spec/ducalis/cops/uncommented_gem_spec.rb
@@ -24,4 +24,32 @@ RSpec.describe Ducalis::UncommentedGem do
                    ])
     expect(cop).to_not raise_violation
   end
+
+  it 'ignores gems with require directive' do
+    inspect_source(cop,
+                   [
+                     "gem 'pry', '~> 0.10', '>= 0.10.0'",
+                     "gem 'rake', '~> 12.1'",
+                     "gem 'rest-client', require: 'rest_client'"
+                   ])
+    expect(cop).to_not raise_violation
+  end
+
+  it 'ignores gems with group directive' do
+    inspect_source(cop,
+                   [
+                     "gem 'rake', '~> 12.1'",
+                     "gem 'wirble', group: :development"
+                   ])
+    expect(cop).to_not raise_violation
+  end
+
+  it 'ignores gems with group directive and old syntax style' do
+    inspect_source(cop,
+                   [
+                     "gem 'rake', '~> 12.1'",
+                     "gem 'wirble', :group => :development"
+                   ])
+    expect(cop).to_not raise_violation
+  end
 end


### PR DESCRIPTION
Prior to this change ducalis treated all passed non-string arguments
like gem source, it's not true for `require` and `group` directive.

This change should resolve this issue by using additional validations on
args keys