### PR TITLE
[DEV] Move type related logic out of cops

### DIFF
--- a/lib/ducalis.rb
+++ b/lib/ducalis.rb
@@ -31,6 +31,7 @@ require 'ducalis/patched_rubocop/git_runner'
 require 'ducalis/patched_rubocop/git_turget_finder'
 require 'ducalis/patched_rubocop/rubo_cop'
 
+require 'ducalis/cops/extensions/type_resolving'
 require 'ducalis/cops/black_list_suffix'
 require 'ducalis/cops/callbacks_activerecord'
 require 'ducalis/cops/case_mapping'

--- a/lib/ducalis/cops/controllers_except.rb
+++ b/lib/ducalis/cops/controllers_except.rb
@@ -11,12 +11,6 @@ module Ducalis
     FILTERS = %i(before_filter after_filter around_filter
                  before_action after_action around_action).freeze
 
-    def on_class(node)
-      _classdef_node, superclass, _body = *node
-      return if superclass.nil?
-      @triggered = superclass.loc.expression.source =~ /Controller/
-    end
-
     def on_send(node)
       _, method_name, *args = *node
       hash_node = args.find { |subnode| subnode.type == :hash }
@@ -31,7 +25,5 @@ module Ducalis
     def decomposite_hash(args)
       args.to_a.first.children.to_a
     end
-
-    attr_reader :triggered
   end
 end

--- a/lib/ducalis/cops/extensions/type_resolving.rb
+++ b/lib/ducalis/cops/extensions/type_resolving.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module TypeResolving
+  MODELS_CLASS_NAMES = %w(
+    ApplicationRecord
+    ActiveRecord::Base
+  ).freeze
+
+  WORKERS_SUFFIXES = %w(
+    Worker
+    Job
+  ).freeze
+
+  CONTROLLER_SUFFIXES = %w(
+    Controller
+  ).freeze
+
+  def on_class(node)
+    classdef_node, superclass, _body = *node
+    @class_name = classdef_node.loc.expression.source
+    @superclass_name = superclass.loc.expression.source unless superclass.nil?
+    super if defined?(super)
+  end
+
+  private
+
+  def in_controller?
+    return false if @superclass_name.nil?
+    @superclass_name.end_with?(*CONTROLLER_SUFFIXES)
+  end
+
+  def in_model?
+    MODELS_CLASS_NAMES.include?(@superclass_name)
+  end
+
+  def in_worker?
+    @class_name.end_with?(*WORKERS_SUFFIXES)
+  end
+end

--- a/lib/ducalis/cops/module_like_class.rb
+++ b/lib/ducalis/cops/module_like_class.rb
@@ -5,6 +5,7 @@ require 'rubocop'
 module Ducalis
   class ModuleLikeClass < RuboCop::Cop::Cop
     include RuboCop::Cop::DefNode
+
     OFFENSE = <<-MESSAGE.gsub(/^ +\|\s/, '').strip
       | Seems like it will be better to define initialize and pass %<args>s there instead of each method.
     MESSAGE

--- a/lib/ducalis/cops/private_instance_assign.rb
+++ b/lib/ducalis/cops/private_instance_assign.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'rubocop'
+require 'ducalis/cops/extensions/type_resolving'
 
 module Ducalis
   class PrivateInstanceAssign < RuboCop::Cop::Cop
     include RuboCop::Cop::DefNode
+    prepend TypeResolving
+
     OFFENSE = <<-MESSAGE.gsub(/^ +\|\s/, '').strip
       | Don't use controller's filter methods for setting instance variables, use them only for changing application flow, such as redirecting if a user is not authenticated. Controller instance variables are forming contract between controller and view. Keeping instance variables defined in one place makes it easier to: reason, refactor and remove old views, test controllers and views, extract actions to new controllers, etc.
     MESSAGE
@@ -15,14 +18,8 @@ module Ducalis
 
     DETAILS = ADD_OFFENSE
 
-    def on_class(node)
-      _classdef_node, superclass, _body = *node
-      return if superclass.nil?
-      @triggered = superclass.loc.expression.source =~ /Controller/
-    end
-
     def on_ivasgn(node)
-      return unless triggered
+      return unless in_controller?
       return unless non_public?(node)
       return check_memo(node) if node.parent.type == :or_asgn
       add_offense(node, :expression, OFFENSE)
@@ -34,7 +31,5 @@ module Ducalis
       return if node.to_a.first.to_s.start_with?('@_')
       add_offense(node, :expression, [OFFENSE, ADD_OFFENSE].join(' '))
     end
-
-    attr_reader :triggered
   end
 end

--- a/lib/ducalis/cops/too_long_workers.rb
+++ b/lib/ducalis/cops/too_long_workers.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require 'rubocop'
+require 'ducalis/cops/extensions/type_resolving'
 
 module Ducalis
   class TooLongWorkers < RuboCop::Cop::Cop
     include RuboCop::Cop::ClassishLength
+    prepend TypeResolving
 
     OFFENSE = <<-MESSAGE.gsub(/^ +\|\s/, '').strip
       | Seems like your worker is doing too much work, consider of moving business logic to service object. As rule, workers should have only two responsibilities:
@@ -12,19 +14,12 @@ module Ducalis
       | - __Errors handling__: Rescue errors and figure out what to do with them.
     MESSAGE
 
-    WORKERS_SUFFIXES = %w(Worker Job).freeze
-
     def on_class(node)
-      return unless worker_class?(node)
+      return unless in_worker?
       check_code_length(node)
     end
 
     private
-
-    def worker_class?(node)
-      classdef_node, _superclass, _body = *node
-      classdef_node.source.end_with?(*WORKERS_SUFFIXES)
-    end
 
     def message(length, max_length)
       format("#{OFFENSE} [%d/%d]", length, max_length)

--- a/lib/ducalis/cops/useless_only.rb
+++ b/lib/ducalis/cops/useless_only.rb
@@ -22,12 +22,6 @@ module Ducalis
     FILTERS = %i(before_filter after_filter around_filter
                  before_action after_action around_action).freeze
 
-    def on_class(node)
-      _classdef_node, superclass, _body = *node
-      return if superclass.nil?
-      @triggered = superclass.loc.expression.source =~ /Controller/
-    end
-
     def on_send(node)
       _, method_name, *args = *node
       hash_node = args.find { |subnode| subnode.type == :hash }
@@ -43,7 +37,5 @@ module Ducalis
     def decomposite_hash(args)
       args.to_a.first.children.to_a
     end
-
-    attr_reader :triggered
   end
 end


### PR DESCRIPTION
Prior to this change every cop resolved current class type itself. This
change provides special module which allows cop to delegate this
problems to it.