### PR TITLE
[#68] Add params, cache etc to white list for preferable cop

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -817,9 +817,14 @@ User.where(id: 7).save
 User.where(id: 7).save(some_arg: true)
 ```
 
+![](https://placehold.it/10/2cbe4e/000000?text=+) ignores calling `delete` on params
+```ruby
+params.delete(code)
+```
+
 ![](https://placehold.it/10/2cbe4e/000000?text=+) ignores calling `delete` with symbol
 ```ruby
-params.delete(:code)
+some_hash.delete(:code)
 ```
 
 ![](https://placehold.it/10/2cbe4e/000000?text=+) ignores calling `delete` with string

--- a/lib/ducalis/cops/preferable_methods.rb
+++ b/lib/ducalis/cops/preferable_methods.rb
@@ -7,11 +7,13 @@ module Ducalis
       | Prefer to use %<alternative>s method instead of %<original>s because of %<reason>s.
     MESSAGE
 
+    WHITE_LIST = %w(cache file params attrs options).freeze
+
     ALWAYS_TRUE = ->(_who, _what, _args) { true }
 
     DELETE_CHECK = lambda do |who, _what, args|
       !%i(sym str).include?(args.first && args.first.type) &&
-        args.count <= 1 && who.to_s !~ /file/
+        args.count <= 1 && !WHITE_LIST.any? { |regex| who.to_s.include?(regex) }
     end
 
     VALIDATE_CHECK = lambda do |_who, _what, args|

--- a/spec/ducalis/cops/preferable_methods_spec.rb
+++ b/spec/ducalis/cops/preferable_methods_spec.rb
@@ -33,8 +33,13 @@ RSpec.describe Ducalis::PreferableMethods do
     expect(cop).to_not raise_violation
   end
 
+  it 'ignores calling `delete` on params' do
+    inspect_source(cop, 'params.delete(code)')
+    expect(cop).to_not raise_violation
+  end
+
   it 'ignores calling `delete` with symbol' do
-    inspect_source(cop, 'params.delete(:code)')
+    inspect_source(cop, 'some_hash.delete(:code)')
     expect(cop).to_not raise_violation
   end
 


### PR DESCRIPTION
It will be nice to rethink this cop, Rails uses `delete` method in many
cases so it will be nice to introduce some another variant or at least
add ability for user to declare exceptions for this rule