### PR TITLE
[#116] Proper paths resolving

### DIFF
--- a/lib/ducalis/git_access.rb
+++ b/lib/ducalis/git_access.rb
@@ -28,7 +28,7 @@ class GitAccess
   end
 
   def for(path)
-    find(path)
+    find(Pathname.new(path).relative_path_from(Pathname.new(Dir.pwd)).to_s)
   end
 
   private

--- a/spec/ducalis/commentators/github_spec.rb
+++ b/spec/ducalis/commentators/github_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Ducalis::Commentators::Github do
   context "when PR doesn't have any previous comments" do
     before do
       expect(octokit).to receive(:pull_request_comments).and_return([])
+      allow(Dir).to receive(:pwd).and_return('')
     end
 
     it 'comments offenses' do

--- a/spec/ducalis/git_access_spec.rb
+++ b/spec/ducalis/git_access_spec.rb
@@ -62,11 +62,18 @@ RSpec.describe GitAccess do
   describe '#for' do
     before { expect(subject).to receive(:changes).and_return([diff]) }
 
+    it 'resolves files with complex paths' do
+      expect(Dir).to receive(:pwd).and_return('/a/b/c/d')
+      expect(subject.for('/a/b/c/d/path')).to eq(diff)
+    end
+
     it 'returns diff for passed path' do
+      expect(Dir).to receive(:pwd).and_return('')
       expect(subject.for('path')).to eq(diff)
     end
 
     it 'returns nil diff for unknown path' do
+      expect(Dir).to receive(:pwd).and_return('')
       expect(subject.for('unknown_path').patch_line).to eq(-1)
     end
   end


### PR DESCRIPTION
Previously Ducalis mistakenly detect file paths which start from root, now paths
properly maps to relative paths in project folder
