### PR TITLE
[#112] Prevent Ducalis from reporting multiple comments

### DIFF
--- a/lib/ducalis/utils.rb
+++ b/lib/ducalis/utils.rb
@@ -9,7 +9,9 @@ module Ducalis
     def octokit
       @octokit ||= begin
         token = ENV.fetch('GITHUB_TOKEN') { raise MissingToken }
-        Octokit::Client.new(access_token: token)
+        Octokit::Client.new(access_token: token).tap do |client|
+          client.auto_paginate = true
+        end
       end
     end
 

--- a/spec/ducalis/utils_spec.rb
+++ b/spec/ducalis/utils_spec.rb
@@ -8,6 +8,7 @@ require './lib/ducalis/errors'
 RSpec.describe Ducalis::Utils do
   describe '#octokit' do
     let(:token) { '7103donotforgettoremovemefromgit' }
+    let(:client) { instance_double(Octokit::Client) }
 
     it 'raises missing token error when there is no key in ENV' do
       stub_const('ENV', {})
@@ -17,6 +18,8 @@ RSpec.describe Ducalis::Utils do
     it 'returns configured octokit version' do
       stub_const('ENV', 'GITHUB_TOKEN' => token)
       expect(Octokit::Client).to receive(:new).with(access_token: token)
+                                              .and_return(client)
+      expect(client).to receive(:auto_paginate=).with(true)
       described_class.octokit
     end
   end


### PR DESCRIPTION
By default octokit returns 30 record per request, this code fixes it and forces
octokit to return always all records.