### PR TITLE
[#123] Enforce Facade code to raise warnings for each line

### DIFF
--- a/lib/ducalis/cops/facade_pattern.rb
+++ b/lib/ducalis/cops/facade_pattern.rb
@@ -19,8 +19,9 @@ module Ducalis
     def on_def(node)
       return unless in_controller?
       return if non_public?(node)
-      return if instance_variables_matches(node).count < max_instance_variables
-      add_offense(node, :expression, OFFENSE)
+      assigns = instance_variables_matches(node)
+      return if assigns.count < max_instance_variables
+      assigns.each { |assign| add_offense(assign, :expression, OFFENSE) }
     end
 
     private

--- a/spec/ducalis/cops/facade_pattern_spec.rb
+++ b/spec/ducalis/cops/facade_pattern_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Ducalis::FacadePattern do
                      '  end',
                      'end'
                    ])
-    expect(cop).to raise_violation(/Facade/)
+    expect(cop).to raise_violation(/Facade/, count: 6)
   end
 
   it '[rule] better to use facade pattern' do


### PR DESCRIPTION
This code enforces raising warnings for each line of code to exclude situations
with `branch` mode. Previously cop raised violation on method definition so it's
 ok in common, but because method definition wasn't changed violation was droped
 by changes filter.