### PR TITLE
[#140] Resolve File.delete case

### DIFF
--- a/lib/ducalis/cops/complex_cases/smart_delete_check.rb
+++ b/lib/ducalis/cops/complex_cases/smart_delete_check.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ComplexCases
+  class SmartDeleteCheck
+    WHITE_LIST = %w[File cache file params attrs options].freeze
+
+    def self.call(who, what, args)
+      !new(who, what, args).false_positive?
+    end
+
+    def initialize(who, _what, args)
+      @who = who
+      @args = args
+    end
+
+    def false_positive?
+      [
+        called_with_stringlike?,
+        many_args?,
+        whitelisted?
+      ].any?
+    end
+
+    private
+
+    def called_with_stringlike?
+      %i[sym str].include?(@args.first && @args.first.type)
+    end
+
+    def many_args?
+      @args.count > 1
+    end
+
+    def whitelisted?
+      WHITE_LIST.any? { |regex| @who.to_s.include?(regex) }
+    end
+  end
+end

--- a/lib/ducalis/cops/preferable_methods.rb
+++ b/lib/ducalis/cops/preferable_methods.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rubocop'
+require 'ducalis/cops/complex_cases/smart_delete_check'
 
 module Ducalis
   class PreferableMethods < RuboCop::Cop::Cop
@@ -8,14 +9,7 @@ module Ducalis
       | Prefer to use %<alternative>s method instead of %<original>s because of %<reason>s.
     MESSAGE
 
-    WHITE_LIST = %w[cache file params attrs options].freeze
-
     ALWAYS_TRUE = ->(_who, _what, _args) { true }
-
-    DELETE_CHECK = lambda do |who, _what, args|
-      !%i[sym str].include?(args.first && args.first.type) &&
-        args.count <= 1 && WHITE_LIST.none? { |regex| who.to_s.include?(regex) }
-    end
 
     VALIDATE_CHECK = lambda do |_who, _what, args|
       (args.first && args.first.source) =~ /validate/
@@ -40,7 +34,7 @@ module Ducalis
       delete: [
         '`destroy`',
         'it is not invoking callbacks',
-        DELETE_CHECK
+        ComplexCases::SmartDeleteCheck
       ],
       delete_all: [
         '`destroy_all`',

--- a/spec/ducalis/cops/complex_cases/smart_delete_check_spec.rb
+++ b/spec/ducalis/cops/complex_cases/smart_delete_check_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+SingleCov.covered!
+
+require 'spec_helper'
+require 'parser/ast/node'
+require './lib/ducalis/cops/complex_cases/smart_delete_check'
+
+RSpec.describe ComplexCases::SmartDeleteCheck do
+  let(:who) { instance_double(Parser::AST::Node) }
+  let(:node) { instance_double(Parser::AST::Node) }
+
+  describe '.call' do
+    let(:check_kass) { instance_double(described_class, false_positive?: true) }
+
+    it 'delegates false_positive calling with not' do
+      expect(described_class).to receive(:new).and_return(check_kass)
+      expect(described_class.call(:who, :what, :args)).to be false
+    end
+  end
+
+  describe '#false_positive?' do
+    context 'when string argument passed' do
+      subject { described_class.new(who, nil, [node]) }
+
+      it 'returns true' do
+        expect(node).to receive(:type).and_return(:str)
+        expect(subject.false_positive?).to be true
+      end
+    end
+
+    context 'when there are many arguments' do
+      subject { described_class.new(who, nil, [node, node]) }
+
+      it 'returns true' do
+        expect(node).to receive(:type).and_return(:non_string)
+        expect(subject.false_positive?).to be true
+      end
+    end
+
+    context 'when caller is whitelisted' do
+      subject { described_class.new(who, nil, [node]) }
+
+      it 'returns true' do
+        expect(node).to receive(:type).and_return(:non_string)
+        expect(who).to receive(:to_s).and_return('File')
+        expect(subject.false_positive?).to be true
+      end
+    end
+  end
+end

--- a/spec/ducalis/cops/preferable_methods_spec.rb
+++ b/spec/ducalis/cops/preferable_methods_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe Ducalis::PreferableMethods do
     expect(cop).not_to raise_violation
   end
 
+  it 'ignores calling `delete` on File class' do
+    inspect_source('File.delete')
+    expect(cop).not_to raise_violation
+  end
+
   it 'ignores calling `delete` on files-like variables' do
     inspect_source('tempfile.delete')
     expect(cop).not_to raise_violation


### PR DESCRIPTION
Delete method check became too complex. Moved it out to separate class
whit more friendly interface and more descriptive method names too
understand what's going on inside.