### PR TITLE
[#134] Make it clear how to use Ducalis

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ __Ducalis__ is CLI application. By defaukt it will notify you about any possible
  violations in CLI.
 
 ```
-ducalis
+ducalis .
 ducalis app/controllers/
 ```
 
@@ -32,16 +32,16 @@ __Ducalis__ allows to pass build even with violations it's make sense to run
 __Ducalis__ across current branch or index:
 
 ```
-ducalis --branch
-ducalis --index
+ducalis --branch .
+ducalis --index .
 ```
 
 Additionally you can pass `--reporter` argument to notify about found violations
  in boundaries of PR:
 
 ```
-ducalis --reporter "author/repo#42"
-ducalis --reporter "circleci"
+ducalis --reporter "author/repo#42" .
+ducalis --reporter "circleci" .
 ```
 
 _N.B._ You should provide `GITHUB_TOKEN` Env to allow __Ducalis__ download your

--- a/config/.ducalis.yml
+++ b/config/.ducalis.yml
@@ -5,8 +5,6 @@ AllCops:
     - 'db/**/*'
     - 'node_modules/**/*'
     - 'vendor/bundle/**/*'
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Ducalis/BlackListSuffix:
   Enabled: true
@@ -54,7 +52,7 @@ Ducalis/PossibleTap:
   Enabled: false
 
 Ducalis/PublicSend:
-  Enabled: false
+  Enabled: true
 
 Ducalis/FetchExpression:
   Enabled: true


### PR DESCRIPTION
- Need to use dot to refer current dir because RuboCop uses a little
bit strange path resolving
- So do not need to add spec folder to global exclude, it works as is
for most cops