### PR TITLE
[#144] Inject cop description link to each offense message

### DIFF
--- a/lib/ducalis/commentators/github.rb
+++ b/lib/ducalis/commentators/github.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ducalis/commentators/message'
+
 module Ducalis
   module Commentators
     class Github
@@ -42,7 +44,7 @@ module Ducalis
 
       def present_offense(offense)
         {
-          body: offense.message,
+          body: Message.new(offense).with_link,
           path: diff_for(offense).path,
           position: diff_for(offense).patch_line(offense.line)
         }

--- a/lib/ducalis/commentators/message.rb
+++ b/lib/ducalis/commentators/message.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Ducalis
+  module Commentators
+    class Message
+      LINK_FORMAT = '[%<cop_name>s](<%<link>s>)'.freeze
+      SITE = 'https://ducalis-rb.github.io'.freeze
+
+      def initialize(offense)
+        @message = offense.message
+        @cop_name = offense.cop_name
+      end
+
+      def with_link
+        if @message.include?(@cop_name)
+          @message.sub(@cop_name, cop_with_link)
+        else
+          [cop_with_link, ': ', @message].join
+        end
+      end
+
+      private
+
+      def cop_with_link
+        format(LINK_FORMAT, cop_name: @cop_name, link: cop_link)
+      end
+
+      def cop_link
+        URI.join(SITE, anchor).to_s
+      end
+
+      def anchor
+        "##{@cop_name.delete('/').downcase}"
+      end
+    end
+  end
+end

--- a/spec/ducalis/commentators/message_spec.rb
+++ b/spec/ducalis/commentators/message_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+SingleCov.covered!
+
+require 'spec_helper'
+require './lib/ducalis/commentators/message'
+
+RSpec.describe Ducalis::Commentators::Message do
+  subject { described_class.new(offense) }
+  let(:offense) do
+    instance_double(RuboCop::Cop::Offense, message: message, cop_name: cop_name)
+  end
+  let(:cop_name) { 'Ducalis/ProtectedScopeCop' }
+
+  context 'with new messages format (which contains copname)' do
+    let(:message) { 'Ducalis/ProtectedScopeCop: A long description.' }
+
+    it 'comments offenses with link to the cop desc', :aggregate_failures do
+      expect(subject.with_link).to include('ducalis-rb')
+      expect(subject.with_link).to include('#ducalisprotectedscopecop')
+      expect(subject.with_link).to include('A long description.')
+    end
+  end
+
+  context 'with old messages format' do
+    let(:message) { 'A long description.' }
+
+    it 'comments offenses with link to the cop desc', :aggregate_failures do
+      expect(subject.with_link).to include('ducalis-rb')
+      expect(subject.with_link).to include('#ducalisprotectedscopecop')
+      expect(subject.with_link).to include('A long description.')
+    end
+  end
+end


### PR DESCRIPTION
I hope it will improve UX. As ducalis supports a bunch of dufferent
rubocop versions need to be sure that we support both rubocop offenses
formats (with inject copname and without).